### PR TITLE
Update anyenv repo and fixate version

### DIFF
--- a/provisioning/roles/anyenv/tasks/main.yml
+++ b/provisioning/roles/anyenv/tasks/main.yml
@@ -9,8 +9,9 @@
 
 - name: fetch anyenv repo
   git:
-    repo: https://github.com/riywo/anyenv
-    dest: '{{ anyenv.dir }}'
+    repo:    https://github.com/anyenv/anyenv
+    version: riywo
+    dest:    '{{ anyenv.dir }}'
   when: anyenv.dir
 
 - name: create plugins dir
@@ -21,6 +22,6 @@
 
 - name: fetch anyenv update repo
   git:
-    repo: https://github.com/znz/anyenv-update.git
+    repo: https://github.com/znz/anyenv-update
     dest: '{{ anyenv.plugins_dir }}/anyenv-update'
   when: anyenv.plugins_dir


### PR DESCRIPTION
## Why

Looks like the creator is working on a new version.
c.f., https://github.com/anyenv/anyenv/issues/66

Not sure if that affects this but master has started failing as he made some changes.

```hcl
fatal: [localhost]: FAILED! => {
    "changed": true,
    "cmd": [
        "bash",
        "-lc",
        "anyenv install rbenv"
    ],
    "delta": "0:00:00.109582",
    "end": "2019-01-24 01:07:20.716738",
    "invocation": {
        "module_args": {
            "_raw_params": "bash -lc 'anyenv install rbenv'",
            "_uses_shell": false,
            "argv": null,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "warn": true
        }
    },
    "msg": "non-zero return code",
    "rc": 2,
    "start": "2019-01-24 01:07:20.607156",
    "stderr": "\\e[33mANYENV_DEFINITION_ROOT(/Users/travis/.config/anyenv/anyenv-install) doesn't exist. You can initialize it by:\\e[0m\n\\e[33m> anyenv install --init\\e[0m",
    "stderr_lines": [
        "\\e[33mANYENV_DEFINITION_ROOT(/Users/travis/.config/anyenv/anyenv-install) doesn't exist. You can initialize it by:\\e[0m",
        "\\e[33m> anyenv install --init\\e[0m"
    ],
    "stdout": "anyenv-install: definition not found: rbenv",
    "stdout_lines": [
        "anyenv-install: definition not found: rbenv"
    ]
}
```