### PR TITLE
Remove six.py

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,10 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Fix environment
+          command: |
+            rm /usr/local/lib/python3.9/site-packages/six.py
+      - run:
           name: up
           command: ./up << parameters.up-opts >> -vvvv
           no_output_timeout: 90m


### PR DESCRIPTION
## Why

https://app.circleci.com/pipelines/github/creasty/dotfiles/91/workflows/b09b1669-89f4-459a-a274-595a26f01dd6

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink lib/python3.9/site-packages/six.py
Target /usr/local/lib/python3.9/site-packages/six.py
already exists. You may want to remove it:
  rm '/usr/local/lib/python3.9/site-packages/six.py'

To force the link and overwrite all conflicting files:
  brew link --overwrite six

To list all files that would be deleted:
  brew link --overwrite --dry-run six
```